### PR TITLE
fix: add a context manager to properly close mrc files

### DIFF
--- a/polnet/lio.py
+++ b/polnet/lio.py
@@ -3,7 +3,7 @@ I/O functions
 
 """
 
-__author__ = 'Antonio Martinez-Sanchez'
+__author__ = "Antonio Martinez-Sanchez"
 
 import vtk
 import csv
@@ -24,12 +24,15 @@ def load_mrc(fname, mmap=False, no_saxes=True):
     :return: a ndarray (or memmap is mmap=True)
     """
     if mmap:
-        mrc = mrcfile.mmap(fname, permissive=True, mode='r+')
+        with mrcfile.mmap(fname, permissive=True, mode="r+") as mrc:
+            data = mrc.data.copy()
     else:
-        mrc = mrcfile.open(fname, permissive=True, mode='r+')
+        with mrcfile.open(fname, permissive=True, mode="r+") as mrc:
+            data = mrc.data.copy()
+
     if no_saxes:
-        return np.swapaxes(mrc.data, 0, 2)
-    return mrc.data
+        return np.swapaxes(data, 0, 2)
+    return data
 
 
 def write_mrc(tomo, fname, v_size=1, dtype=None, no_saxes=True):
@@ -68,7 +71,7 @@ def read_mrc_v_size(fname):
     :return: a 3-tuple with the voxel size in Angstrom for each dimension (X, Y, Z)
     """
     with mrcfile.mmap(fname) as mrc:
-        return (mrc.voxel_size['x'], mrc.voxel_size['y'], mrc.voxel_size['z'])
+        return (mrc.voxel_size["x"], mrc.voxel_size["y"], mrc.voxel_size["z"])
 
 
 def save_vtp(poly, fname):
@@ -126,17 +129,35 @@ def load_csv_into_tomo_tables(in_csv_file):
     :return: a dictionary where each density path is an entry for a table, each table contains all particles of single
              density
     """
-    tables_df = pd.read_csv(in_csv_file, delimiter='\t', names=['Density Micrographs', 'PolyData', 'Tomo3D', 'Type',
-                                                                 'Label', 'Code', 'Polymer', 'X', 'Y', 'Z',
-                                                                 'Q1', 'Q2', 'Q3', 'Q4'], header=0)
-    den_tomos = set(tables_df['Tomo3D'].tolist())
+    tables_df = pd.read_csv(
+        in_csv_file,
+        delimiter="\t",
+        names=[
+            "Density Micrographs",
+            "PolyData",
+            "Tomo3D",
+            "Type",
+            "Label",
+            "Code",
+            "Polymer",
+            "X",
+            "Y",
+            "Z",
+            "Q1",
+            "Q2",
+            "Q3",
+            "Q4",
+        ],
+        header=0,
+    )
+    den_tomos = set(tables_df["Tomo3D"].tolist())
     tables_dic = dict().fromkeys(den_tomos)
     for key in tables_dic:
         tables_dic[key] = dict().fromkeys(tables_df.columns.tolist())
         for kkey in tables_dic[key]:
             tables_dic[key][kkey] = list()
     for row in tables_df.iterrows():
-        key = row[1]['Tomo3D']
+        key = row[1]["Tomo3D"]
         for item, value in row[1].items():
             tables_dic[key][item].append(value)
     return tables_dic
@@ -150,9 +171,9 @@ def write_table(table, out_file):
     :param out_file: path for the output file
     :return:
     """
-    with open(out_file, 'w', newline='') as csv_file:
+    with open(out_file, "w", newline="") as csv_file:
         fieldnames = list(table.keys())
-        writer = csv.DictWriter(csv_file, fieldnames=fieldnames, delimiter='\t')
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames, delimiter="\t")
         writer.writeheader()
         for row in range(len(table[fieldnames[0]])):
             dic_row = dict().fromkeys(fieldnames)
@@ -171,7 +192,9 @@ def numpy_to_vti(tomo: np.ndarray, dtype=vtk.VTK_FLOAT) -> vtk.vtkImageData:
     """
     assert len(tomo.shape) == 3
 
-    vtk_data = numpy_to_vtk(num_array=tomo.flatten(), deep=True, array_type=dtype)
+    vtk_data = numpy_to_vtk(
+        num_array=tomo.flatten(), deep=True, array_type=dtype
+    )
     img = vtk.vtkImageData()
     img.GetPointData().SetScalars(vtk_data)
     img.SetDimensions(tomo.shape[0], tomo.shape[1], tomo.shape[2])


### PR DESCRIPTION
This PR is a dummy fix to properly close mrc files after loading them.

Not doing so could introduce corruption, especially when dealing with multi-threading scripts (I have an example of such problems...).