### PR TITLE
fix: tilt_rg should be inclusive

### DIFF
--- a/src/polnet/tem/tem.py
+++ b/src/polnet/tem/tem.py
@@ -400,7 +400,7 @@ class TEM:
         """
         tilt_rg = tem_params["TILT_ANGS_RG"]
         tilt_step = tem_params["TILT_ANGS_STEP"]
-        tilt_angs = np.arange(tilt_rg[0], tilt_rg[1], tilt_step)
+        tilt_angs = np.arange(tilt_rg[0], tilt_rg[1] + 1, tilt_step)
 
         logger.debug("Generating tilt series.")
         self.gen_tilt_series_imod(density, tilt_angs, ax="Y")


### PR DESCRIPTION
A TILT_ANGS_RG setting (e.g., (-60, 60)) is inclusive. Hence, the angles should be `np.arange(tilt_rg[0], tilt_rg[1] + 1, tilt_step)`.
